### PR TITLE
Defined maximum message size

### DIFF
--- a/include.h
+++ b/include.h
@@ -15,6 +15,7 @@
 #define SERVER_MQ_IND				0
 
 #define MQ_MAX_MESSAGE				1024
+#define MQ_MAX_MESSAGE_SIZE			72
 
 #define MQ_NAME_LEN 				32
 

--- a/server.c
+++ b/server.c
@@ -136,7 +136,7 @@ int encrypt_password(char *password, int password_length, char *key, int key_len
 int update_decrypters(PASSWORD_MSG_T message, int message_size) {
 	for (int i = 1; i < MAX_CONNECTIONS + 1; i++) {
 		if (mqs[i] != -1) {
-			mq_send(mqs[i], (char*) message, message_size, NEW_PASSWORD_PRIORITY);
+			mq_send(mqs[i], (char*) message, MQ_MAX_MESSAGE_SIZE, NEW_PASSWORD_PRIORITY);
 		}
 	}
 }


### PR DESCRIPTION
Added `MQ_MAX_MESSAGE_SIZE` definition in `include.h`. Set to be 72 - 64 bytes for the password + 4 bytes length + 4 bytes type.